### PR TITLE
Register macro only when ResponseFactory is resolved

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Laravel;
 
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Support\Facades\Response as ResponseFacade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Intervention\Image\ImageManager;
@@ -27,7 +28,7 @@ class ServiceProvider extends BaseServiceProvider
             __DIR__ . '/../config/image.php' => config_path(Facades\Image::BINDING . '.php')
         ]);
 
-        $this->app->booted(function (): void {
+        $this->app->afterResolving(ResponseFactory::class, function (): void {
             // register response macro "image"
             if ($this->shouldCreateResponseMacro()) {
                 ResponseFacade::macro(Facades\Image::BINDING, function (


### PR DESCRIPTION
I am doing custom manipulation with session in a middleware in several of my projects, which worked without problem previously. Recently noticed that the session in my projects is not working as intended. After tracking down the bug, this happened because `intervention/image-laravel` package now registers a response macro after the app is booted.

After changing the registration of macro to occur after the `ResponseFactory` class is resolved, the issue is resolved.