### PR TITLE
Add PHPStan stub for ResponseFactory::image() macro

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,11 @@
             "aliases": {
                 "Image": "Intervention\\Image\\Laravel\\Facades\\Image"
             }
+        },
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
         }
     }
 }

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,3 @@
+parameters:
+    stubFiles:
+        - stubs/ResponseFactory.stub

--- a/stubs/ResponseFactory.stub
+++ b/stubs/ResponseFactory.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Contracts\Routing;
+
+use Illuminate\Http\Response;
+use Intervention\Image\FileExtension;
+use Intervention\Image\Format;
+use Intervention\Image\Image;
+use Intervention\Image\MediaType;
+
+/**
+ * @method Response image(Image $image, null|string|Format|MediaType|FileExtension $format = null, mixed ...$options)
+ */
+interface ResponseFactory
+{
+}


### PR DESCRIPTION
## Summary

Resolves #24

Larastan reports `Call to an undefined method Illuminate\Contracts\Routing\ResponseFactory::image()` because the `image()` macro is registered at runtime via `ServiceProvider::boot()`, which static analysis tools cannot detect.

This PR adds a PHPStan stub and extension config so PHPStan/Larastan recognizes the `image()` method on ResponseFactory

## Changes

- `stubs/ResponseFactory.stub` — Declares `image()` via `@method` PHPDoc on `Illuminate\Contracts\Routing\ResponseFactory`, matching the macro signature in `ServiceProvider.php`
- extension.neon— Registers the stub with PHPStan
- composer.json — Added `extra.phpstan.includes` for auto-discovery (zero user config needed)

## Verification

```bash
vendor/bin/phpstan analyse fixture.php -c extension.neon --level=max
```

```php
// fixture.php
<?php

use Illuminate\Contracts\Routing\ResponseFactory;
use Intervention\Image\Image;

function test(ResponseFactory $factory, Image $image): void
{
    $factory->image($image);
    $factory->image($image, 'webp');
    $factory->image($image, null, quality: 80);
}
```

### Expected Result

<img width="635" height="158" alt="Screenshot_2026-03-09_10-27-50" src="https://github.com/user-attachments/assets/cfff37d0-5559-4307-ba71-d0ab7f27df01" />
