### PR TITLE
fix: update parameters to accept image interface

### DIFF
--- a/src/ImageResponseFactory.php
+++ b/src/ImageResponseFactory.php
@@ -9,8 +9,8 @@ use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\NotSupportedException;
 use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\FileExtension;
+use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Format;
-use Intervention\Image\Image;
 use Intervention\Image\MediaType;
 
 class ImageResponseFactory
@@ -25,13 +25,13 @@ class ImageResponseFactory
     /**
      * Create new ImageResponseFactory instance
      *
-     * @param Image $image
+     * @param ImageInterface $image
      * @param null|string|Format|MediaType|FileExtension $format
      * @param mixed ...$options
      * @return void
      */
     public function __construct(
-        protected Image $image,
+        protected ImageInterface $image,
         protected null|string|Format|MediaType|FileExtension $format = null,
         mixed ...$options
     ) {
@@ -41,7 +41,7 @@ class ImageResponseFactory
     /**
      * Static factory method to create HTTP response directly
      *
-     * @param Image $image
+     * @param ImageInterface $image
      * @param null|string|Format|MediaType|FileExtension $format
      * @param mixed ...$options
      * @throws NotSupportedException
@@ -50,7 +50,7 @@ class ImageResponseFactory
      * @return Response
      */
     public static function make(
-        Image $image,
+        ImageInterface $image,
         null|string|Format|MediaType|FileExtension $format = null,
         mixed ...$options,
     ): Response {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Response as ResponseFacade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Image;
+use Intervention\Image\Interfaces\ImageInterface;
 use Illuminate\Http\Response;
 use Intervention\Image\FileExtension;
 use Intervention\Image\Format;
@@ -32,7 +33,7 @@ class ServiceProvider extends BaseServiceProvider
             // register response macro "image"
             if ($this->shouldCreateResponseMacro()) {
                 ResponseFacade::macro(Facades\Image::BINDING, function (
-                    Image $image,
+                    ImageInterface $image,
                     null|string|Format|MediaType|FileExtension $format = null,
                     mixed ...$options,
                 ): Response {


### PR DESCRIPTION
Hello!

The following code is generating this error in phpstan:

```php
        $fileStream = $file->filesystem()->readStream($file->path);
        assert($fileStream !== null);

        $image = Image::read($fileStream)->scale($width, $height);

        return response()->image($image);
```

```
Parameter #1 $image of method Illuminate\\Routing\\ResponseFactory::image() expects Intervention\\Image\\Image, Intervention\\Image\\Interfaces\\ImageInterface given.
```

This is because the `Image` facade types these as the interface but the other methods accept the concrete class.

Thanks!