### PR TITLE
fix: larastan unable to recognize macro

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Laravel;
 
-use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Support\Facades\Response as ResponseFacade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Intervention\Image\ImageManager;
@@ -28,17 +27,19 @@ class ServiceProvider extends BaseServiceProvider
             __DIR__ . '/../config/image.php' => config_path(Facades\Image::BINDING . '.php')
         ]);
 
-        $this->app->afterResolving(ResponseFactory::class, function (): void {
-            // register response macro "image"
-            if ($this->shouldCreateResponseMacro()) {
-                ResponseFacade::macro(Facades\Image::BINDING, function (
-                    ImageInterface $image,
-                    null|string|Format|MediaType|FileExtension $format = null,
-                    mixed ...$options,
-                ): Response {
-                    return ImageResponseFactory::make($image, $format, ...$options);
-                });
+        // register response macro "image"
+        ResponseFacade::resolved(function ($factory): void {
+            if ($factory::hasMacro(Facades\Image::BINDING)) {
+                return;
             }
+
+            $factory::macro(Facades\Image::BINDING, function (
+                ImageInterface $image,
+                null|string|Format|MediaType|FileExtension $format = null,
+                mixed ...$options,
+            ): Response {
+                return ImageResponseFactory::make($image, $format, ...$options);
+            });
         });
     }
 
@@ -63,17 +64,5 @@ class ServiceProvider extends BaseServiceProvider
                 strip: config('image.options.strip', false)
             );
         });
-    }
-
-    /**
-     * Determine if response macro should be created
-     */
-    private function shouldCreateResponseMacro(): bool
-    {
-        if (!$this->app->runningUnitTests() && $this->app->runningInConsole()) {
-            return false;
-        }
-
-        return !ResponseFacade::hasMacro(Facades\Image::BINDING);
     }
 }


### PR DESCRIPTION
Hello!

Every time I run PHPStan I'm getting this false positive:

<img width="748" height="181" alt="image" src="https://github.com/user-attachments/assets/f6fac39c-f742-4f15-8420-bd2ea49de941" />

Larastan recognizes macros because it boots the application and checks if this exists. However, it's not going to recognize it if the macro is never registered when running in console.

Registering a macro is very lightweight (literally just an array key assignment) so there's no performance implications to this.

Thanks!