### PR TITLE
Fix package compatibility with laravel 13.20

### DIFF
--- a/src/Facades/Image.php
+++ b/src/Facades/Image.php
@@ -27,7 +27,7 @@ class Image extends Facade
     /**
      * Binding name of the service container
      */
-    public const BINDING = 'image';
+    public const BINDING = 'intervention.image';
 
     protected static function getFacadeAccessor()
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,7 +25,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         // define config files for publishing
         $this->publishes([
-            __DIR__ . '/../config/image.php' => config_path(Facades\Image::BINDING . '.php'),
+            __DIR__ . '/../config/image.php' => config_path('image.php'),
         ]);
 
         // register response macro "image"
@@ -53,7 +53,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->mergeConfigFrom(
             __DIR__ . '/../config/image.php',
-            Facades\Image::BINDING,
+            'image',
         );
 
         $this->app->singleton(Facades\Image::BINDING, function () {

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -31,7 +31,7 @@ final class FacadeTest extends TestBenchTestCase
         $reflection = new ReflectionClass(ImageFacade::class);
         $method = $reflection->getMethod('getFacadeAccessor');
         $method->setAccessible(true);
-        $this->assertSame('image', $method->invoke(null));
+        $this->assertSame('intervention.image', $method->invoke(null));
     }
 
     public function testReadAnImage(): void


### PR DESCRIPTION
- Laravel recently introduced its own [Image facade](https://github.com/laravel/framework/pull/59276) in Laravel `13.20`
- Laravel uses the same container binding key for its facade: `image`, which conflicts with this package
- This PR renames this package’s container binding key to `intervention.image` to avoid the conflict
- This change is potentially breaking for anyone resolving the image manager directly from the container with `app('image')` instead of using the facade
- There may be a better solution that I'm not aware of.

