### PR TITLE
Fix nested image configuration keys

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -86,9 +86,9 @@ class ServiceProvider extends BaseServiceProvider
         return [
             'driver' => config($filename . '.driver'),
             'autoOrientation' => config($filename . '.options.autoOrientation', true),
-            'decodeAnimation' => config($filename . 'image.options.decodeAnimation', true),
-            'backgroundColor' => config($filename . 'image.options.backgroundColor', 'ffffff'),
-            'strip' => config($filename . 'image.options.strip', false),
+            'decodeAnimation' => config($filename . '.options.decodeAnimation', true),
+            'backgroundColor' => config($filename . '.options.backgroundColor', 'ffffff'),
+            'strip' => config($filename . '.options.strip', false),
         ];
     }
 

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Facade;
 use Intervention\Image\Exceptions\DirectoryNotFoundException;
 use Intervention\Image\Exceptions\InvalidArgumentException;
+use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Laravel\Facades\Image as ImageFacade;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -32,6 +33,21 @@ final class FacadeTest extends TestBenchTestCase
         $method = $reflection->getMethod('getFacadeAccessor');
         $method->setAccessible(true);
         $this->assertSame('intervention.image', $method->invoke(null));
+    }
+
+    public function testImageManagerUsesConfiguredOptions(): void
+    {
+        config([
+            'intervention-image.options.decodeAnimation' => false,
+            'intervention-image.options.backgroundColor' => '000000',
+            'intervention-image.options.strip' => true,
+        ]);
+
+        $manager = $this->app->make(ImageFacade::BINDING);
+        $this->assertInstanceOf(ImageManager::class, $manager);
+        $this->assertFalse($manager->driver->config()->decodeAnimation);
+        $this->assertSame('000000', $manager->driver->config()->backgroundColor);
+        $this->assertTrue($manager->driver->config()->strip);
     }
 
     public function testReadAnImage(): void


### PR DESCRIPTION
Fixes #35.

Correct the configuration keys used for `decodeAnimation`, `backgroundColor`, and `strip`, and add a regression test confirming the configured values reach the image manager.

Tested with `docker compose run --rm --build tests`.
